### PR TITLE
fix example of the option in the proposals (the delimiter is a space, not a comma)

### DIFF
--- a/src/micromamba/NOTES.md
+++ b/src/micromamba/NOTES.md
@@ -23,15 +23,15 @@ More generally, `channels` can be a space-separated list such as "conda-forge de
 
 This Feature supports package installation during image build.
 
-Specify package names separated by commas in the `packages` option.
+Specify package names separated by **spaces** in the `packages` option.
 
-For example, specify like the following installs `python` and `r-base`.
+For example, specify like the following installs `python>=3.11,<3.12` and `r-base`.
 
 ```json
 "features": {
   "ghcr.io/mamba-org/devcontainer-features/micromamba:1": {
     "channels": "conda-forge",
-    "packages": "python r-base"
+    "packages": "python>=3.11,<3.12 r-base"
   }
 }
 ```

--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "micromamba",
     "id": "micromamba",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Installs micromamba, the fast cross-platform package manager.",
     "documentationURL": "https://github.com/mamba-org/devcontainer-features/tree/main/src/micromamba",
     "options": {

--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -31,7 +31,7 @@
             "default": "",
             "proposals": [
                 "",
-                "python r-base"
+                "python>=3.11,<3.12 r-base"
             ],
             "description": "Space separated list of packages to install. Should use with the 'channels' option."
         },

--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -31,7 +31,7 @@
             "default": "",
             "proposals": [
                 "",
-                "python,r-base"
+                "python r-base"
             ],
             "description": "Space separated list of packages to install. Should use with the 'channels' option."
         },


### PR DESCRIPTION
We changed the delimiter from a comma to a space in #11, but forgot to update the proposals.