### PR TITLE
Fix shell init for users

### DIFF
--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "micromamba",
     "id": "micromamba",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Installs micromamba, the fast cross-platform package manager.",
     "documentationURL": "https://github.com/mamba-org/devcontainer-features/tree/main/src/micromamba",
     "options": {

--- a/src/micromamba/install.sh
+++ b/src/micromamba/install.sh
@@ -66,12 +66,17 @@ run_as_user() {
 
 micromamba_as_user() {
     run_as_user "$(which micromamba)" "${@}"
-}    
+}
+
+fix_base_env_directory_permissions() {
+    find "${MAMBA_ROOT_PREFIX}" -type d -print0 | xargs -n 1 -0 chmod g+sw
+}
 
 micromamba_install_as_user() {
     if [ -n "$*" ]; then
         echo "Installing packages..."
         micromamba_as_user install --root-prefix="${MAMBA_ROOT_PREFIX}" --prefix="${MAMBA_ROOT_PREFIX}" -y "${@}"
+        fix_base_env_directory_permissions
     fi
 }
 
@@ -100,7 +105,7 @@ initialize_root_prefix() {
     usermod -a -G conda "${USERNAME}"
     chown -R "${USERNAME}:conda" "${MAMBA_ROOT_PREFIX}"
     chmod -R g+r+w "${MAMBA_ROOT_PREFIX}"
-    find "${MAMBA_ROOT_PREFIX}" -type d -print0 | xargs -n 1 -0 chmod g+sw
+    fix_base_env_directory_permissions
 }
 
 add_channels() {

--- a/src/micromamba/install.sh
+++ b/src/micromamba/install.sh
@@ -100,7 +100,7 @@ initialize_root_prefix() {
     usermod -a -G conda "${USERNAME}"
     chown -R "${USERNAME}:conda" "${MAMBA_ROOT_PREFIX}"
     chmod -R g+r+w "${MAMBA_ROOT_PREFIX}"
-    find "${MAMBA_ROOT_PREFIX}" -type d -print0 | xargs -n 1 -0 chmod g+s
+    find "${MAMBA_ROOT_PREFIX}" -type d -print0 | xargs -n 1 -0 chmod g+sw
 }
 
 add_channels() {

--- a/src/micromamba/install.sh
+++ b/src/micromamba/install.sh
@@ -61,7 +61,7 @@ install_micromamba() {
 run_as_user() {
     local cmd=("$@")
     quoted="$(printf "'%s' " "${cmd[@]}")"
-    su - "${USERNAME}" -c "${quoted}"
+    su --whitelist-environment=MAMBA_ROOT_PREFIX - "${USERNAME}" -c "${quoted}"
 }
 
 micromamba_as_user() {

--- a/test/micromamba/scenarios.json
+++ b/test/micromamba/scenarios.json
@@ -1,4 +1,15 @@
 {
+    "test-user-activation": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "micromamba": {
+                "channels": "conda-forge",
+                "packages": "wget"
+            }
+        }
+    },
     "install-specific-version": {
         "image": "ghcr.io/maresb/docker-debian-curl",
         "features": {

--- a/test/micromamba/test-user-activation.sh
+++ b/test/micromamba/test-user-activation.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+check_user_activation() {
+    whoami | grep vscode
+    groups | grep conda
+    echo $MAMBA_ROOT_PREFIX | grep "^/opt/conda$"
+    micromamba list | grep wget
+    ls -al "/opt/conda/bin"
+    micromamba remove -y wget
+}
+check "checking user activation" check_user_activation
+
+reportResults

--- a/test/micromamba/test-user-activation/Dockerfile
+++ b/test/micromamba/test-user-activation/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/maresb/docker-debian-curl
+
+# Create a new user named vscode
+RUN useradd -m -s /bin/bash vscode
+
+USER vscode


### PR DESCRIPTION
Closes #19

When the shell was being initialized, the `MAMBA_ROOT_PREFIX` environment variable was not passed through by the `su` command. This caused the shell activation to default to `~/micromamba`. But we install packages to `/opt/conda`, so this presents as the user getting an empty environment.

Passing through `MAMBA_ROOT_PREFIX` solves the problem.