### PR TITLE
add autoActivate argument

### DIFF
--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "micromamba",
     "id": "micromamba",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "description": "Installs micromamba, the fast cross-platform package manager.",
     "documentationURL": "https://github.com/mamba-org/devcontainer-features/tree/main/src/micromamba",
     "options": {

--- a/src/micromamba/devcontainer-feature.json
+++ b/src/micromamba/devcontainer-feature.json
@@ -18,6 +18,11 @@
             "default": false,
             "description": "Reinstall in case Micromamba already exists"
         },
+        "autoActivate": {
+            "type": "boolean",
+            "default": true,
+            "description": "Auto activation of base environment"
+        },
         "channels": {
             "type": "string",
             "default": "",

--- a/src/micromamba/install.sh
+++ b/src/micromamba/install.sh
@@ -9,6 +9,7 @@ cd "${FEATURE_DIR}"
 # Options
 VERSION=${VERSION:-"latest"}
 ALLOW_REINSTALL=${ALLOWREINSTALL:-"false"}
+AUTO_ACTIVATE=${AUTOACTIVATE:-"true"}
 IFS=' ' read -r -a CHANNELS <<< "$CHANNELS"  # Convert space-separated list to array
 IFS=' ' read -r -a PACKAGES <<< "$PACKAGES"  # Convert space-separated list to array
 ENV_FILE=${ENVFILE:-""}
@@ -178,13 +179,17 @@ micromamba_as_user config set channel_priority strict
 echo "Initializing Bash shell"
 micromamba_as_user shell init --shell=bash
 
-echo "Setting Bash shell to automatically activate"
-su -c "if ! grep -q 'micromamba activate # added by micromamba devcontainer feature' ~/.bashrc; then echo 'micromamba activate # added by micromamba devcontainer feature' >> ~/.bashrc; fi" - "${USERNAME}"
+if [ "${AUTO_ACTIVATE}" = "true" ]; then
+    echo "Setting Bash shell to automatically activate"
+    su -c "if ! grep -q 'micromamba activate # added by micromamba devcontainer feature' ~/.bashrc; then echo 'micromamba activate # added by micromamba devcontainer feature' >> ~/.bashrc; fi" - "${USERNAME}"
+fi
 
 if type zsh > /dev/null 2>&1; then
     echo "Initializing zsh shell"
     micromamba_as_user shell init --shell=zsh
-    su -c "if ! grep -q 'micromamba activate # added by micromamba devcontainer feature' ~/.zshrc; then echo 'micromamba activate # added by micromamba devcontainer feature' >> ~/.zshrc; fi" - "${USERNAME}"
+    if [ "${AUTO_ACTIVATE}" = "true" ]; then
+        su -c "if ! grep -q 'micromamba activate # added by micromamba devcontainer feature' ~/.zshrc; then echo 'micromamba activate # added by micromamba devcontainer feature' >> ~/.zshrc; fi" - "${USERNAME}"
+    fi
 fi
 
 echo "Micromamba configured."

--- a/test/micromamba/scenarios.json
+++ b/test/micromamba/scenarios.json
@@ -101,5 +101,13 @@
                 "envName": "testenv"
             }
         }
+    },
+    "test-no-auto-activate":{
+        "image": "ghcr.io/maresb/docker-debian-curl",
+        "features": {
+            "micromamba": {
+                "autoActivate": false
+            }
+        }   
     }
 }

--- a/test/micromamba/test-no-auto-activate.sh
+++ b/test/micromamba/test-no-auto-activate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+check_no_env() {
+    test -z "$CONDA_DEFAULT_ENV"
+    test -z "$CONDA_PREFIX"
+}
+check "not in conda environment" check_no_env
+
+reportResults


### PR DESCRIPTION
Added an `autoActivate` argument so that auto activation of the base environment can be manually disabled.